### PR TITLE
fix: bump build target, correctly downlevel transpile

### DIFF
--- a/rollup/config.lib.ts
+++ b/rollup/config.lib.ts
@@ -33,7 +33,7 @@ export default formats.map(
           : {
               tsconfigOverride: {
                 compilerOptions: {
-                  target: 'es5',
+                  target: 'es6',
                 },
               },
             }


### PR DESCRIPTION
Fixes #89 and #86, following up #94, where things aren't being transpiled correctly.

According to https://esbuild.github.io/api/#target:

> If you use a syntax feature that esbuild doesn't yet have support for transforming to your current language target, esbuild will generate an error where the unsupported syntax is used. This is often the case when targeting the `es5` language version, for example, since esbuild only supports transforming most newer JavaScript syntax features to `es6`.

Also see https://esbuild.github.io/content-types/#javascript as for JS features by version.