### PR TITLE
strip out 3D API version

### DIFF
--- a/src/internal/cleanRenderer.ts
+++ b/src/internal/cleanRenderer.ts
@@ -11,7 +11,11 @@ export function cleanRenderer(renderer: string) {
     // Strip off [number]gb & strip off direct3d and after - for example:
     // 'Radeon (TM) RX 470 Series Direct3D11 vs_5_0 ps_5_0' becomes
     // 'Radeon (TM) RX 470 Series'
-    .replace(/\s(\d{1,2}gb|direct3d.+$)|\(r\)| \([^)]+\)$/g, '');
+    .replace(/\s(\d{1,2}gb|direct3d.+$)|\(r\)| \([^)]+\)$/g, '')
+    // Strip off Vulkan x.x.x () - for example:
+    // 'vulkan 1.2.175 (nvidia nvidia geforce gtx 970 (0x000013c2))'
+    // becomes 'nvidia nvidia geforce gtx 970 (0x000013c2)'
+    .replace(/vulkan \d+\.\d+\.\d+ \((.*)\)/, '$1')
 
   debug?.('cleanRenderer - renderer cleaned to', { renderer });
 

--- a/src/internal/cleanRenderer.ts
+++ b/src/internal/cleanRenderer.ts
@@ -12,10 +12,12 @@ export function cleanRenderer(renderer: string) {
     // 'Radeon (TM) RX 470 Series Direct3D11 vs_5_0 ps_5_0' becomes
     // 'Radeon (TM) RX 470 Series'
     .replace(/\s(\d{1,2}gb|direct3d.+$)|\(r\)| \([^)]+\)$/g, '')
-    // Strip off Vulkan x.x.x () - for example:
-    // 'vulkan 1.2.175 (nvidia nvidia geforce gtx 970 (0x000013c2))'
+    // Strip out graphics API. The one Vulkan example we've seen includes
+    // the GPU in parens after the Vulkan version so this also keeps that
+    // eg. 'vulkan 1.2.175 (nvidia nvidia geforce gtx 970 (0x000013c2))'
     // becomes 'nvidia nvidia geforce gtx 970 (0x000013c2)'
-    .replace(/vulkan \d+\.\d+\.\d+ \((.*)\)/, '$1')
+    // `OpenGL 4.5.0` gets removed all together
+    .replace(/(?:vulkan|opengl) \d+\.\d+(?:\.\d+)?(?: \((.*)\))?/, '$1')
 
   debug?.('cleanRenderer - renderer cleaned to', { renderer });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -238,6 +238,15 @@ for (const { input, expected } of [
       renderer: 'ANGLE (NVIDIA, Vulkan 1.2.175 (NVIDIA NVIDIA GeForce GTX 970 (0x000013C2)), NVIDIA)',
     },
   },
+  {
+    expected: {
+      gpu: 'amd renoir',
+    },
+    input: {
+      isMobile: false,
+      renderer: 'amd, amd renoir (llvm 14.0.6), opengl 4.6)',
+    },
+  },
 ]) {
   test(`${input.renderer} should find ${expected.gpu}`, async () => {
     expectGPUResults(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -229,6 +229,15 @@ for (const { input, expected } of [
       renderer: 'Mali-G51',
     },
   },
+  {
+    expected: {
+      gpu: 'nvidia evga geforce gtx 970',
+    },
+    input: {
+      isMobile: false,
+      renderer: 'ANGLE (NVIDIA, Vulkan 1.2.175 (NVIDIA NVIDIA GeForce GTX 970 (0x000013C2)), NVIDIA)',
+    },
+  },
 ]) {
   test(`${input.renderer} should find ${expected.gpu}`, async () => {
     expectGPUResults(


### PR DESCRIPTION
Might not be the greatest implementation since I only have this one example, but this strips out what looks to be a Vulkan version may have started showing up in Chrome 105 on Linux.