### PR TITLE
Fix WEBGL_debug_renderer_info deprecation in Firefox

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -291,6 +291,8 @@ export const getGPUTier = async ({
 
     if (debugRendererInfo) {
       renderer = gl.getParameter(debugRendererInfo.UNMASKED_RENDERER_WEBGL);
+    } else {
+      renderer = gl.getParameter(gl.RENDERER);
     }
 
     if (!renderer) {


### PR DESCRIPTION
It should fix the issue [87](https://github.com/pmndrs/detect-gpu/issues/87)