### PR TITLE
Upgrade workflow runners to ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test:
     name: Run test & lint
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/update-benchmark.yml
+++ b/.github/workflows/update-benchmark.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   auto-update:
     name: Automated benchmarks update
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/scripts/update_benchmarks.ts
+++ b/scripts/update_benchmarks.ts
@@ -184,7 +184,7 @@ type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 });
 
 async function fetchBenchmarks() {
-  const browser = await puppeteer.launch({ headless: true });
+  const browser = await puppeteer.launch({ headless: true, args: ["--no-sandbox", "--disable-setuid-sandbox"] });
   const page = await browser.newPage();
 
   await page.goto(BENCHMARK_URL, { waitUntil: 'networkidle2' });


### PR DESCRIPTION
Upgraded the GitLab runners to use ubuntu-latest to prevent job timeouts caused by unavailable runners. As a consequence of this upgrade, the new environment causes Chromium’s sandbox to fail when Puppeteer launches. To resolve this, --no-sandbox and --disable-setuid-sandbox were enabled.