### PR TITLE
feat(ios): extend Apple GPU detection with missing chips + iOS version filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
     "build": "tsdown",
     "update-benchmarks": "node ./scripts/update_benchmarks.ts"
   },
-  "dependencies": {
-    "webgl-constants": "^1.1.1"
-  },
   "devDependencies": {
     "@types/node": "^25.6.0",
     "@types/tar": "^7.0.87",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      webgl-constants:
-        specifier: ^1.1.1
-        version: 1.1.1
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -1380,9 +1376,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  webgl-constants@1.1.1:
-    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
-
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -2459,8 +2452,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-
-  webgl-constants@1.1.1: {}
 
   webidl-conversions@8.0.1: {}
 

--- a/src/internal/deobfuscateAppleGPU.ts
+++ b/src/internal/deobfuscateAppleGPU.ts
@@ -58,7 +58,7 @@ export function deobfuscateAppleGPU(
         ['m2', codeA, 15], // ipad pro 11 6nd gen / ipad pro 12.9 6th gen
         ['m3', codeA, 15], // ipad air 11-inch (m3, 2025) / ipad air 13-inch (m3, 2025)
         ['m4', codeA, 15], // ipad pro 11-inch (m4, 2024) / ipad pro 13-inch (m4, 2024)
-        ['m5', codeA, 15], // expected next-generation ipad pro / ipad air models
+        ['m5', codeA, 15], // ipad pro 11-inch (m5, 2025) / ipad pro 13-inch (m5, 2025)
       ]
     : [
         // ['a4', 7], // 4 / ipod touch 4th gen
@@ -75,10 +75,10 @@ export function deobfuscateAppleGPU(
         ['a15', codeA, 15], // 13 / 13 mini / 13 pro / 13 pro max / se 3rd gen / 14 / 14 plus
         ['a16', codeA, 15], // 14 pro / 14 pro max / 15 / 15 plus
         ['a17', codeA, 15], // 15 pro / 15 pro max
-        ['a18', codeA, 15], // iphone 16 / iphone 16 plus
+        ['a18', codeA, 15], // iphone 16 / iphone 16 plus / iphone 16e
         ['a18 pro', codeA, 15], // iphone 16 pro / iphone 16 pro max
-        ['a19', codeA, 15], // expected next-generation base iphone models
-        ['a19 pro', codeA, 15], // expected next-generation iphone pro models
+        ['a19', codeA, 15], // iphone 17
+        ['a19 pro', codeA, 15], // iphone 17 air / iphone 17 pro / iphone 17 pro max
       ];
   let chipsets: typeof possibleChipsets;
 

--- a/src/internal/deobfuscateAppleGPU.ts
+++ b/src/internal/deobfuscateAppleGPU.ts
@@ -1,18 +1,18 @@
-// Vendor
-import {
-  GL_ARRAY_BUFFER,
-  GL_COLOR_BUFFER_BIT,
-  GL_FLOAT,
-  GL_FRAGMENT_SHADER,
-  GL_RGBA,
-  GL_STATIC_DRAW,
-  GL_TRIANGLES,
-  GL_UNSIGNED_BYTE,
-  GL_VERTEX_SHADER,
-} from 'webgl-constants';
-
-// Internal
 import { deviceInfo } from './deviceInfo';
+
+// WebGL enum values, inlined to avoid a dep on `webgl-constants`. Same
+// numbers as `gl.ARRAY_BUFFER` etc., which minifiers can't fold because
+// they're property accesses. SEE:
+// https://registry.khronos.org/webgl/specs/latest/1.0/#5.14
+const GL_ARRAY_BUFFER = 0x8892;
+const GL_COLOR_BUFFER_BIT = 0x4000;
+const GL_FLOAT = 0x1406;
+const GL_FRAGMENT_SHADER = 0x8b30;
+const GL_RGBA = 0x1908;
+const GL_STATIC_DRAW = 0x88e4;
+const GL_TRIANGLES = 0x0004;
+const GL_UNSIGNED_BYTE = 0x1401;
+const GL_VERTEX_SHADER = 0x8b31;
 
 const debug = false ? console.warn : undefined;
 
@@ -25,74 +25,78 @@ export function deobfuscateAppleGPU(
     debug?.('Safari 14+ obfuscates its GPU type and version, using fallback');
     return [renderer];
   }
-  const pixelId = calculateMagicPixelId(gl);
   const codeA = '801621810' as const;
   const codeB = '8016218135' as const;
   const codeC = '80162181161' as const;
   const codeFB = '80162181255';
 
   // All chipsets that support at least iOS 12:
-  const possibleChipsets: [
-    string,
-    typeof codeA | typeof codeB | typeof codeC,
-    number,
-  ][] = deviceInfo?.isIpad
-    ? [
-        // ['a4', 5], // ipad 1st gen
-        // ['a5', 9], // ipad 2 / ipad mini 1st gen
-        // ['a5x', 9], // ipad 3rd gen
-        // ['a6x', 10], // ipad 4th gen
-        ['a7', codeC, 12], // ipad air / ipad mini 2 / ipad mini 3
-        ['a8', codeB, 15], // pad mini 4
-        ['a8x', codeB, 15], // ipad air 2
-        ['a9', codeB, 15], // ipad 5th gen
-        ['a9x', codeB, 15], // pro 9.7 2016 / pro 12.9 2015
-        ['a10', codeB, 15], // ipad 7th gen / ipad 6th gen
-        ['a10x', codeB, 15], // pro 10.5 2017 / pro 12.9 2nd gen, 2017
-        ['a12', codeA, 15], // ipad 8th gen / ipad air 3rd gen / ipad mini 5th gen
-        ['a12x', codeA, 15], // ipad pro 11 3st gen / ipad pro 12.9 3rd gen
-        ['a12z', codeA, 15], // ipad pro 11 4nd gen / ipad pro 12.9 4th gen
-        ['a14', codeA, 15], // ipad air 4th gen
-        ['a15', codeA, 15], // ipad mini 6th gen / ipad 10th gen
-        ['m1', codeA, 15], // ipad pro 11 5nd gen / ipad pro 12.9 5th gen / ipad air 5th gen
-        ['m2', codeA, 15], // ipad pro 11 6nd gen / ipad pro 12.9 6th gen
-        ['m3', codeA, 15], // ipad air 11-inch (m3, 2025) / ipad air 13-inch (m3, 2025)
-        ['m4', codeA, 15], // ipad pro 11-inch (m4, 2024) / ipad pro 13-inch (m4, 2024)
-        ['m5', codeA, 15], // ipad pro 11-inch (m5, 2025) / ipad pro 13-inch (m5, 2025)
-      ]
-    : [
-        // ['a4', 7], // 4 / ipod touch 4th gen
-        // ['a5', 9], // 4S / ipod touch 5th gen
-        // ['a6', 10], // 5 / 5C
-        ['a7', codeC, 12], // 5S
-        ['a8', codeB, 12], // 6 / 6 plus / ipod touch 6th gen
-        ['a9', codeB, 15], // 6s / 6s plus/ se 1st gen
-        ['a10', codeB, 15], // 7 / 7 plus / iPod Touch 7th gen
-        ['a11', codeA, 15], // 8 / 8 plus / X
-        ['a12', codeA, 15], // XS / XS Max / XR
-        ['a13', codeA, 15], // 11 / 11 pro / 11 pro max / se 2nd gen
-        ['a14', codeA, 15], // 12 / 12 mini / 12 pro / 12 pro max
-        ['a15', codeA, 15], // 13 / 13 mini / 13 pro / 13 pro max / se 3rd gen / 14 / 14 plus
-        ['a16', codeA, 15], // 14 pro / 14 pro max / 15 / 15 plus
-        ['a17', codeA, 15], // 15 pro / 15 pro max
-        ['a18', codeA, 15], // iphone 16 / iphone 16 plus / iphone 16e
-        ['a18 pro', codeA, 15], // iphone 16 pro / iphone 16 pro max
-        ['a19', codeA, 15], // iphone 17
-        ['a19 pro', codeA, 15], // iphone 17 air / iphone 17 pro / iphone 17 pro max
-      ];
-  let chipsets: typeof possibleChipsets;
-
-  // In iOS 14.x Apple started normalizing the outcome of this hack,
-  // we use this fact to limit the list to devices that support ios 14+
-  if (pixelId === codeFB) {
-    chipsets = possibleChipsets.filter(([, , iosVersion]) => iosVersion >= 14);
-  } else {
-    chipsets = possibleChipsets.filter(([, id]) => id === pixelId);
-    // If nothing was found to match the pixel id, include all chipsets:
-    if (!chipsets.length) {
-      chipsets = possibleChipsets;
+  let chipsets: [string, typeof codeA | typeof codeB | typeof codeC, number][] =
+    deviceInfo?.isIpad
+      ? [
+          // ['a4', 5], // ipad 1st gen
+          // ['a5', 9], // ipad 2 / ipad mini 1st gen
+          // ['a5x', 9], // ipad 3rd gen
+          // ['a6x', 10], // ipad 4th gen
+          ['a7', codeC, 12], // ipad air / ipad mini 2 / ipad mini 3
+          ['a8', codeB, 15], // pad mini 4
+          ['a8x', codeB, 15], // ipad air 2
+          ['a9', codeB, 15], // ipad 5th gen
+          ['a9x', codeB, 15], // pro 9.7 2016 / pro 12.9 2015
+          ['a10', codeB, 15], // ipad 7th gen / ipad 6th gen
+          ['a10x', codeB, 15], // pro 10.5 2017 / pro 12.9 2nd gen, 2017
+          ['a12', codeA, 15], // ipad 8th gen / ipad air 3rd gen / ipad mini 5th gen
+          ['a12x', codeA, 15], // ipad pro 11 3st gen / ipad pro 12.9 3rd gen
+          ['a12z', codeA, 15], // ipad pro 11 4nd gen / ipad pro 12.9 4th gen
+          ['a14', codeA, 15], // ipad air 4th gen
+          ['a15', codeA, 15], // ipad mini 6th gen / ipad 10th gen
+          ['a16', codeA, 15], // ipad air 11 / ipad air 13 (a16, 2025) / ipad 11th gen
+          ['a17 pro', codeA, 15], // ipad mini 7th gen
+          ['m1', codeA, 15], // ipad pro 11 5nd gen / ipad pro 12.9 5th gen / ipad air 5th gen
+          ['m2', codeA, 15], // ipad pro 11 6nd gen / ipad pro 12.9 6th gen
+          ['m3', codeA, 15], // ipad air 11-inch (m3, 2025) / ipad air 13-inch (m3, 2025)
+          ['m4', codeA, 15], // ipad pro 11-inch (m4, 2024) / ipad pro 13-inch (m4, 2024)
+          ['m5', codeA, 15], // ipad pro 11-inch (m5, 2025) / ipad pro 13-inch (m5, 2025)
+        ]
+      : [
+          // ['a4', 7], // 4 / ipod touch 4th gen
+          // ['a5', 9], // 4S / ipod touch 5th gen
+          // ['a6', 10], // 5 / 5C
+          ['a7', codeC, 12], // 5S
+          ['a8', codeB, 12], // 6 / 6 plus / ipod touch 6th gen
+          ['a9', codeB, 15], // 6s / 6s plus/ se 1st gen
+          ['a10', codeB, 15], // 7 / 7 plus / iPod Touch 7th gen
+          ['a11', codeA, 15], // 8 / 8 plus / X
+          ['a12', codeA, 15], // XS / XS Max / XR
+          ['a13', codeA, 15], // 11 / 11 pro / 11 pro max / se 2nd gen
+          ['a14', codeA, 15], // 12 / 12 mini / 12 pro / 12 pro max
+          ['a15', codeA, 15], // 13 / 13 mini / 13 pro / 13 pro max / se 3rd gen / 14 / 14 plus
+          ['a16', codeA, 15], // 14 pro / 14 pro max / 15 / 15 plus
+          ['a17 pro', codeA, 15], // 15 pro / 15 pro max
+          ['a18', codeA, 15], // iphone 16 / iphone 16 plus / iphone 16e
+          ['a18 pro', codeA, 15], // iphone 16 pro / iphone 16 pro max
+          ['a19', codeA, 15], // iphone 17
+          ['a19 pro', codeA, 15], // iphone 17 air / iphone 17 pro / iphone 17 pro max
+        ];
+  // On iOS 14+ the pixel ID was normalized by Apple and only tells us
+  // "iOS 14+" — which the UA-based iOSVersion already does, without a
+  // WebGL draw call. Skip the shader when we can.
+  const skipShader =
+    deviceInfo?.iOSVersion !== undefined && deviceInfo.iOSVersion >= 14;
+  if (!skipShader) {
+    const pixelId = calculateMagicPixelId(gl);
+    if (pixelId === codeFB) {
+      chipsets = chipsets.filter(([, , iosVersion]) => iosVersion >= 14);
+    } else {
+      const matched = chipsets.filter(([, id]) => id === pixelId);
+      if (matched.length) chipsets = matched;
     }
   }
+  chipsets = filterByIOSVersion(
+    chipsets,
+    deviceInfo?.iOSVersion,
+    !!deviceInfo?.isIpad
+  );
   const renderers = chipsets.map(([gpu]) => `apple ${gpu} gpu`);
   debug?.(
     `iOS 12.2+ obfuscates its GPU type and version, using closest matches: ${JSON.stringify(
@@ -100,6 +104,36 @@ export function deobfuscateAppleGPU(
     )}`
   );
   return renderers;
+}
+
+const IOS_CHIP_CUTOFFS = [
+  { minIOS: 13, iphone: 9, ipad: 8 },
+  { minIOS: 16, iphone: 10, ipad: 9 },
+  { minIOS: 17, iphone: 12, ipad: 10 },
+  { minIOS: 26, iphone: 13, ipad: 12 },
+];
+
+function minimumAChip(iOSVersion: number, isIpad: boolean): number {
+  const cutoff = IOS_CHIP_CUTOFFS.findLast((c) => iOSVersion >= c.minIOS);
+  return cutoff ? (isIpad ? cutoff.ipad : cutoff.iphone) : 0;
+}
+
+// Drop A-series chipsets that cannot run the detected iOS major. M-series
+// chips (2021+) and any unrecognized prefix are preserved.
+/** @internal — exported for test access only. */
+export function filterByIOSVersion<T extends readonly [string, ...unknown[]]>(
+  chipsets: T[],
+  iOSVersion: number | undefined,
+  isIpad: boolean
+): T[] {
+  if (!iOSVersion) return chipsets;
+  const minAChip = minimumAChip(iOSVersion, isIpad);
+  if (!minAChip) return chipsets;
+  return chipsets.filter(([gpu]) => {
+    if (gpu.startsWith('m')) return true;
+    const match = /^a(\d+)/.exec(gpu);
+    return match ? parseInt(match[1], 10) >= minAChip : true;
+  });
 }
 
 // Apple GPU (iOS 12.2+, Safari 14+)

--- a/src/internal/deobfuscateAppleGPU.ts
+++ b/src/internal/deobfuscateAppleGPU.ts
@@ -56,6 +56,9 @@ export function deobfuscateAppleGPU(
         ['a15', codeA, 15], // ipad mini 6th gen / ipad 10th gen
         ['m1', codeA, 15], // ipad pro 11 5nd gen / ipad pro 12.9 5th gen / ipad air 5th gen
         ['m2', codeA, 15], // ipad pro 11 6nd gen / ipad pro 12.9 6th gen
+        ['m3', codeA, 15], // ipad air 11-inch (m3, 2025) / ipad air 13-inch (m3, 2025)
+        ['m4', codeA, 15], // ipad pro 11-inch (m4, 2024) / ipad pro 13-inch (m4, 2024)
+        ['m5', codeA, 15], // expected next-generation ipad pro / ipad air models
       ]
     : [
         // ['a4', 7], // 4 / ipod touch 4th gen
@@ -72,6 +75,10 @@ export function deobfuscateAppleGPU(
         ['a15', codeA, 15], // 13 / 13 mini / 13 pro / 13 pro max / se 3rd gen / 14 / 14 plus
         ['a16', codeA, 15], // 14 pro / 14 pro max / 15 / 15 plus
         ['a17', codeA, 15], // 15 pro / 15 pro max
+        ['a18', codeA, 15], // iphone 16 / iphone 16 plus
+        ['a18 pro', codeA, 15], // iphone 16 pro / iphone 16 pro max
+        ['a19', codeA, 15], // expected next-generation base iphone models
+        ['a19 pro', codeA, 15], // expected next-generation iphone pro models
       ];
   let chipsets: typeof possibleChipsets;
 

--- a/src/internal/deviceInfo.ts
+++ b/src/internal/deviceInfo.ts
@@ -1,5 +1,30 @@
 import { isSSR } from './ssr';
 
+// iOS 26+ freezes the legacy "iPhone OS 18_6" token as a fingerprinting
+// countermeasure, so we prefer the Safari "Version/" token whenever it
+// disagrees upward — except on pre-iOS-7 UAs where Version/ tracked Safari
+// (then 4 or 5), not iOS. Returns undefined for in-app browsers that expose
+// the version only in proprietary tokens (FBSV, etc.).
+//
+// `isAppleMobile` must be true only for iPhone/iPod/iPad UAs (including the
+// iPadOS-as-MacIntel masquerade). On those UAs Safari's Version/ tracks the
+// iOS/iPadOS major; on real macOS it tracks the macOS major and would yield
+// a wrong number — the gate is the only thing keeping that out.
+export function parseIOSVersion(
+  userAgent: string,
+  isAppleMobile: boolean
+): number | undefined {
+  if (!isAppleMobile) return undefined;
+  const osMatch = /(?:iPhone|CPU) OS (\d+)[._ ;)]/.exec(userAgent);
+  const versionMatch = /Version\/(\d+)/.exec(userAgent);
+  const os = osMatch ? parseInt(osMatch[1], 10) : undefined;
+  const version = versionMatch ? parseInt(versionMatch[1], 10) : undefined;
+  if (os !== undefined && version !== undefined) {
+    return os >= 7 && version > os ? version : os;
+  }
+  return os ?? version;
+}
+
 export const deviceInfo = (() => {
   if (isSSR) {
     return;
@@ -19,10 +44,13 @@ export const deviceInfo = (() => {
 
   const isAndroid = /android/i.test(userAgent);
 
+  const iOSVersion = parseIOSVersion(userAgent, isIOS || isIpad);
+
   return {
     isIpad,
     isMobile: isAndroid || isIOS || isIpad,
     isSafari12: /Version\/12.+Safari/.test(userAgent),
     isFirefox: /Firefox/.test(userAgent),
+    iOSVersion,
   };
 })();

--- a/test/deobfuscateAppleGPU.test.ts
+++ b/test/deobfuscateAppleGPU.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'vitest';
+
+import { filterByIOSVersion } from '../src/internal/deobfuscateAppleGPU';
+
+// Minimal shape matching the possibleChipsets tuple in deobfuscateAppleGPU.ts.
+// The filter only reads the first element (gpu name) so the rest is ignored.
+type Chipset = readonly [string, unknown, number];
+
+const iphoneChipsets: Chipset[] = [
+  ['a7', 'code', 12],
+  ['a8', 'code', 12],
+  ['a9', 'code', 15],
+  ['a10', 'code', 15],
+  ['a11', 'code', 15],
+  ['a12', 'code', 15],
+  ['a13', 'code', 15],
+  ['a14', 'code', 15],
+  ['a15', 'code', 15],
+  ['a16', 'code', 15],
+  ['a17 pro', 'code', 15],
+  ['a18', 'code', 15],
+  ['a18 pro', 'code', 15],
+  ['a19', 'code', 15],
+  ['a19 pro', 'code', 15],
+];
+
+const ipadChipsets: Chipset[] = [
+  ['a7', 'code', 12],
+  ['a8', 'code', 15],
+  ['a8x', 'code', 15],
+  ['a9', 'code', 15],
+  ['a9x', 'code', 15],
+  ['a10', 'code', 15],
+  ['a10x', 'code', 15],
+  ['a12', 'code', 15],
+  ['a12x', 'code', 15],
+  ['a12z', 'code', 15],
+  ['a14', 'code', 15],
+  ['a15', 'code', 15],
+  ['a16', 'code', 15],
+  ['a17 pro', 'code', 15],
+  ['m1', 'code', 15],
+  ['m2', 'code', 15],
+  ['m3', 'code', 15],
+  ['m4', 'code', 15],
+  ['m5', 'code', 15],
+];
+
+const names = (chipsets: Chipset[]) => chipsets.map(([gpu]) => gpu);
+
+describe('filterByIOSVersion', () => {
+  test('returns every chipset when iOS version is unknown', () => {
+    expect(filterByIOSVersion(iphoneChipsets, undefined, false)).toEqual(
+      iphoneChipsets
+    );
+    expect(filterByIOSVersion(ipadChipsets, undefined, true)).toEqual(
+      ipadChipsets
+    );
+  });
+
+  test('applies no cutoff below iOS 13', () => {
+    expect(names(filterByIOSVersion(iphoneChipsets, 12, false))).toEqual(
+      names(iphoneChipsets)
+    );
+  });
+
+  test('iOS 13 drops A8 and below on iPhone (requires A9+)', () => {
+    const result = names(filterByIOSVersion(iphoneChipsets, 13, false));
+    expect(result).not.toContain('a7');
+    expect(result).not.toContain('a8');
+    expect(result[0]).toBe('a9');
+  });
+
+  test('iOS 16 drops A9 and below on iPhone (requires A10+)', () => {
+    const result = names(filterByIOSVersion(iphoneChipsets, 16, false));
+    expect(result).not.toContain('a9');
+    expect(result[0]).toBe('a10');
+  });
+
+  test('iOS 17 drops A11 and below on iPhone (requires A12+)', () => {
+    const result = names(filterByIOSVersion(iphoneChipsets, 17, false));
+    expect(result).not.toContain('a10');
+    expect(result).not.toContain('a11');
+    expect(result[0]).toBe('a12');
+  });
+
+  test('iOS 18 uses the same cutoff as iOS 17', () => {
+    expect(names(filterByIOSVersion(iphoneChipsets, 18, false))).toEqual(
+      names(filterByIOSVersion(iphoneChipsets, 17, false))
+    );
+  });
+
+  test('iPadOS 16 drops A8x and below on iPad (requires A9+)', () => {
+    const result = names(filterByIOSVersion(ipadChipsets, 16, true));
+    expect(result).not.toContain('a8');
+    expect(result).not.toContain('a8x');
+    expect(result[0]).toBe('a9');
+  });
+
+  test('iPadOS 17 drops A9x and below on iPad (requires A10+)', () => {
+    const result = names(filterByIOSVersion(ipadChipsets, 17, true));
+    expect(result).not.toContain('a9');
+    expect(result).not.toContain('a9x');
+    expect(result[0]).toBe('a10');
+  });
+
+  test('iOS 26 drops A12 and below on iPhone (requires A13+)', () => {
+    const result = names(filterByIOSVersion(iphoneChipsets, 26, false));
+    expect(result).toEqual([
+      'a13',
+      'a14',
+      'a15',
+      'a16',
+      'a17 pro',
+      'a18',
+      'a18 pro',
+      'a19',
+      'a19 pro',
+    ]);
+  });
+
+  test('iPadOS 26 drops A10 and below on iPad (requires A12+/Neural Engine)', () => {
+    const result = names(filterByIOSVersion(ipadChipsets, 26, true));
+    expect(result).toEqual([
+      'a12',
+      'a12x',
+      'a12z',
+      'a14',
+      'a15',
+      'a16',
+      'a17 pro',
+      'm1',
+      'm2',
+      'm3',
+      'm4',
+      'm5',
+    ]);
+  });
+
+  test('all M-series chips pass every iOS cutoff', () => {
+    const mOnly: Chipset[] = [
+      ['m1', 'code', 15],
+      ['m2', 'code', 15],
+      ['m3', 'code', 15],
+      ['m4', 'code', 15],
+      ['m5', 'code', 15],
+    ];
+    expect(names(filterByIOSVersion(mOnly, 26, true))).toEqual(names(mOnly));
+    expect(names(filterByIOSVersion(mOnly, 99, true))).toEqual(names(mOnly));
+  });
+});

--- a/test/deviceInfo.test.ts
+++ b/test/deviceInfo.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// `deviceInfo` is built by a module-level IIFE that snapshots
+// `window.navigator` at import time. To test different UAs we stub the
+// navigator properties and re-import the module via `vi.resetModules()` so
+// the IIFE re-runs against the stubbed values.
+async function loadDeviceInfo(overrides: {
+  userAgent?: string;
+  platform?: string;
+  maxTouchPoints?: number;
+}) {
+  vi.resetModules();
+  const navigator = window.navigator;
+  const descriptors = {
+    userAgent: Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator),
+      'userAgent'
+    ),
+    platform: Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator),
+      'platform'
+    ),
+    maxTouchPoints: Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator),
+      'maxTouchPoints'
+    ),
+  };
+  Object.defineProperty(navigator, 'userAgent', {
+    value: overrides.userAgent ?? '',
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'platform', {
+    value: overrides.platform ?? '',
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    value: overrides.maxTouchPoints ?? 0,
+    configurable: true,
+  });
+
+  const mod = await import('../src/internal/deviceInfo');
+
+  // Restore so other tests see the jsdom defaults.
+  if (descriptors.userAgent)
+    Object.defineProperty(navigator, 'userAgent', descriptors.userAgent);
+  if (descriptors.platform)
+    Object.defineProperty(navigator, 'platform', descriptors.platform);
+  if (descriptors.maxTouchPoints)
+    Object.defineProperty(
+      navigator,
+      'maxTouchPoints',
+      descriptors.maxTouchPoints
+    );
+
+  return mod.deviceInfo;
+}
+
+describe('deviceInfo.iOSVersion', () => {
+  test('parses iPhone OS major version from UA', async () => {
+    const info = await loadDeviceInfo({
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 26_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1',
+      platform: 'iPhone',
+    });
+    expect(info?.iOSVersion).toBe(26);
+  });
+
+  test('parses iPad OS major version from "CPU OS" UA', async () => {
+    const info = await loadDeviceInfo({
+      userAgent:
+        'Mozilla/5.0 (iPad; CPU OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
+      platform: 'iPad',
+    });
+    expect(info?.iOSVersion).toBe(17);
+  });
+
+  test('reads Version/ on iPadOS masquerading as MacIntel (Request Desktop Site)', async () => {
+    const info = await loadDeviceInfo({
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 5,
+    });
+    expect(info?.isIpad).toBe(true);
+    expect(info?.iOSVersion).toBe(17);
+  });
+
+  test('is undefined on desktop macOS', async () => {
+    const info = await loadDeviceInfo({
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+    });
+    expect(info?.iOSVersion).toBeUndefined();
+  });
+
+  test('is undefined on Android', async () => {
+    const info = await loadDeviceInfo({
+      userAgent:
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36',
+      platform: 'Linux armv8l',
+    });
+    expect(info?.iOSVersion).toBeUndefined();
+  });
+
+  test('parses two-digit version correctly (not greedy on underscores)', async () => {
+    const info = await loadDeviceInfo({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)',
+      platform: 'iPhone',
+    });
+    expect(info?.iOSVersion).toBe(18);
+  });
+});

--- a/test/fixtures/ios-user-agents.json
+++ b/test/fixtures/ios-user-agents.json
@@ -1,0 +1,518 @@
+[
+  {
+    "ua": "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10",
+    "iOSMajor": 3
+  },
+  {
+    "ua": "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5",
+    "iOSMajor": 4
+  },
+  {
+    "ua": "Mozilla/5.0 (iPod touch; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13F69",
+    "iOSMajor": 9
+  },
+  {
+    "ua": "MQQBrowser/371 Mozilla/5.0 (iPhone 4S; CPU iPhone OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10A523 Safari/7534.48.3",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) OPiOS/8.0.1.80062 Mobile/11D201 Safari/9537.53",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "IUC(U;iOS 5.1.1;Zh-cn;320*480;)/UCWEB7.9.0.94/41/997",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; U; CPU iPhone 6_1_4 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Mobile/7E18 Grindr/1.8.8 (iPhone5,2/6.1.4)",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; U; CPU iPhone 7_0 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Mobile/7E18 Grindr/1.8.8 (iPhone3,1/7.0)",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "iTube 2.15 (iPhone; iPhone OS 7.0; en_US)",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "UCWEB/2.0 (iOS; U; iPad OS 6_1_3; en-US; iPad2,5) U2/1.0.0 UCBrowser/9.0.0.260 U2/1.0.0 Mobile",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "UCWEB/2.0 (iOS; U; iPh OS 5_0_1; zh-CN; iPh4,1) U2/1.0.0 UCBrowser/9.0.1.284 U2/1.0.0 Mobile",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "UCWEB/2.0 (iOS; U; iPh OS 7_0_4; ru; iPh3,1) U2/1.0.0 UCBrowser/9.0.0.260 U2/1.0.0 Mobile",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "UCWEB/2.0 (iOS; U; iPh OS 7_0_4; zh-CN; iPh4,1) U2/1.0.0 UCBrowser/9.0.1.284 U2/1.0.0 Mobile",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Mail/53 CFNetwork/711.2.23 Darwin/14.0.0",
+    "iOSMajor": 8
+  },
+  {
+    "ua": "DEPoker-iPad/1.0.2 CFNetwork/548.1.4 Darwin/11.0.0",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "JDSports-iPad/1.1 CFNetwork/672.0.8 Darwin/14.0.0",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "AngryBirdsBlack-iPhone/1.1.0 CFNetwork/548.1.4 Darwin/11.0.0",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "Bing for iPad/1.1.2 CFNetwork/485.13.9 Darwin/11.0.0",
+    "iOSMajor": 4
+  },
+  {
+    "ua": "NightstandPaid-iPad/1.3.1 CFNetwork/548.1.4 Darwin/11.0.0",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "Glo-De-iPad/1.4.7 CFNetwork/672.0.2 Darwin/14.0.0",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Island for iPhone/1.95 CFNetwork/672.0.2 Darwin/14.0.0",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "WormsiPhone-iPad/2.3 CFNetwork/548.1.4 Darwin/11.0.0",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "Rummy LITE iPad/2.3.0 CFNetwork/609.1.4 Darwin/13.0.0",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "MobileRSSFree-iPad/3.1 CFNetwork/467.12 Darwin/10.3.1",
+    "iOSMajor": 4
+  },
+  {
+    "ua": "MobileRSSFree-iPad/3.1.4 CFNetwork/485.13.9 Darwin/11.0.0",
+    "iOSMajor": 4
+  },
+  {
+    "ua": "babbelIndonesian-iPad/4.0.1 CFNetwork/672.0.8 Darwin/14.0.0",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "WeltMobile-iPad/4.2 CFNetwork/609.1.4 Darwin/13.0.0",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "IMPlusFull-iPad/7.9.1 CFNetwork/548.0.4 Darwin/11.0.0",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "Cooliris/1.3 CFNetwork/342.1 Darwin/9.4.1",
+    "iOSMajor": 1
+  },
+  {
+    "ua": "Poof/1.0 CFNetwork/485.12.7 Darwin/10.4.0",
+    "iOSMajor": 4
+  },
+  {
+    "ua": "Parking Mania Free/1.9.5.0 CFNetwork/548.0.4 Darwin/11.0.0",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "Planet Boing!/1.4.8 CFNetwork/609.1.4 Darwin/13.0.0",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "PlayTube/1.7 CFNetwork/672.0.2 Darwin/14.0.0",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "nick/14 CFNetwork/548.0.3 Darwin/11.0.0",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "Parking Mania Free/1.9.5.0 CFNetwork/548.0.4 Darwin/11.0.0",
+    "iOSMajor": 5
+  },
+  {
+    "ua": "JyukenSapuriApp/1.9.0 CFNetwork/609 Darwin/13.0.0",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "DailyBeast/1.1 CFNetwork/672.1.13 Darwin/14.0.0",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Yelp/8.0.0 CFNetwork/672.1.14 Darwin/14.0.0",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Yelp/8.0.0 CFNetwork/672.1.15 Darwin/14.0.0",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Yelp/8.2.1 CFNetwork/705.1 Darwin/14.0.0",
+    "iOSMajor": 8
+  },
+  {
+    "ua": "Yelp/8.2.0 CFNetwork/709.1 Darwin/14.0.0",
+    "iOSMajor": 8
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/894 Darwin/17.4.0",
+    "iOSMajor": 11
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/897.15 Darwin/17.5.0",
+    "iOSMajor": 11
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/901.1 Darwin/17.6.0",
+    "iOSMajor": 11
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/902.2 Darwin/17.7.0",
+    "iOSMajor": 11
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/958.1 Darwin/18.0.0",
+    "iOSMajor": 12
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/976 Darwin/18.2.0",
+    "iOSMajor": 12
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/978.0.7 Darwin/18.5.0",
+    "iOSMajor": 12
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/978.0.7 Darwin/18.6.0",
+    "iOSMajor": 12
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/978.0.7 Darwin/18.7.0",
+    "iOSMajor": 12
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1107.1 Darwin/19.0.0",
+    "iOSMajor": 13
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1098.7 Darwin/19.0.0",
+    "iOSMajor": 13
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1121.2.2 Darwin/19.2.0",
+    "iOSMajor": 13
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1121.2.2 Darwin/19.3.0",
+    "iOSMajor": 13
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1125.2 Darwin/19.4.0",
+    "iOSMajor": 13
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1126 Darwin/19.5.0",
+    "iOSMajor": 13
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1128.0.1 Darwin/19.6.0",
+    "iOSMajor": 13
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1197 Darwin/20.0.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1179.0.1 Darwin/20.0.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1200.1 Darwin/20.1.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1209 Darwin/20.2.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1220.1 Darwin/20.3.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1237 Darwin/20.4.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1206 Darwin/20.1.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1209 Darwin/20.2.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1220.1 Darwin/20.3.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1236 Darwin/20.4.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/1233 Darwin/20.4.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/0 CFNetwork/1240.0.4 Darwin/20.5.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/0 CFNetwork/1240.0.4 Darwin/20.6.0",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "App/0 CFNetwork/1300.1 Darwin/21.0.0",
+    "iOSMajor": 15
+  },
+  {
+    "ua": "App/0 CFNetwork/1325.0.1 Darwin/21.1.0",
+    "iOSMajor": 15
+  },
+  {
+    "ua": "App/0 CFNetwork/1327.0.4 Darwin/21.2.0",
+    "iOSMajor": 15
+  },
+  {
+    "ua": "App/0 CFNetwork/1329 Darwin/21.3.0",
+    "iOSMajor": 15
+  },
+  {
+    "ua": "App/0 CFNetwork/1331.0.7 Darwin/21.4.0",
+    "iOSMajor": 15
+  },
+  {
+    "ua": "App/0 CFNetwork/1333.0.3 Darwin/21.5.0",
+    "iOSMajor": 15
+  },
+  {
+    "ua": "App/0 CFNetwork/1333.0.4 Darwin/21.6.0",
+    "iOSMajor": 15
+  },
+  {
+    "ua": "App/0 CFNetwork/1390 Darwin/22.0.0",
+    "iOSMajor": 16
+  },
+  {
+    "ua": "App/0 CFNetwork/1399 Darwin/22.1.0",
+    "iOSMajor": 16
+  },
+  {
+    "ua": "App/0 CFNetwork/1402 Darwin/22.2.0",
+    "iOSMajor": 16
+  },
+  {
+    "ua": "App/0 CFNetwork/1404.0.5 Darwin/22.3.0",
+    "iOSMajor": 16
+  },
+  {
+    "ua": "App/0 CFNetwork/1406.0.4 Darwin/22.4.0",
+    "iOSMajor": 16
+  },
+  {
+    "ua": "App/0 CFNetwork/1442 Darwin/22.5.0",
+    "iOSMajor": 16
+  },
+  {
+    "ua": "App/0 CFNetwork/1442 Darwin/23.0.0",
+    "iOSMajor": 17
+  },
+  {
+    "ua": "App/0 CFNetwork/1442 Darwin/23.1.0",
+    "iOSMajor": 17
+  },
+  {
+    "ua": "App/0 CFNetwork/1442 Darwin/23.2.0",
+    "iOSMajor": 17
+  },
+  {
+    "ua": "App/0 CFNetwork/1442 Darwin/23.3.0",
+    "iOSMajor": 17
+  },
+  {
+    "ua": "App/0 CFNetwork/1442 Darwin/23.4.0",
+    "iOSMajor": 17
+  },
+  {
+    "ua": "App/0 CFNetwork/1442 Darwin/23.5.0",
+    "iOSMajor": 17
+  },
+  {
+    "ua": "App/0 CFNetwork/1442 Darwin/24.0.0",
+    "iOSMajor": 18
+  },
+  {
+    "ua": "App/0 CFNetwork/1442 Darwin/24.1.0",
+    "iOSMajor": 18
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU 7_0_6 like Mac OS X; en_GB) AppleWebKit (KHTML, like Gecko) Mobile [OKMagazine/4.0.1 (iOS/7.0.6)] [LiteApps]",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Appcelerator Titanium/2.1.2.GA (iPhone/6.1.2; iPhone OS; de_DE;)",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "4 Pics 1 Word/3.9 (iPad; iOS 7.0.2; Scale/2.00)",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "4 Pics 1 Word/3.9 (iPhone; iOS 7.0.2; Scale/2.00)",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "server-bag [iPhone OS,6.1,10B144,iPhone3,2]",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "IUC(U;iOS 6.1.2;Zh-cn;320*480;)/UCWEB8.2.1.132/42/997",
+    "iOSMajor": 6
+  },
+  {
+    "ua": "StoreKitUIService/1.0 iOS/7.0 model/iPhone3,1 (4; dt:27)",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Yahoo!/9184 (iPhone; iOS 7.0.4; Scale/2.00)",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; U; CPU iPhone OS  7_0 like Mac OS X; tr_TR)",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; U; CPU iPhone OS  7_0_2 like Mac OS X; de_DE)",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "TestApp/1.0 CFNetwork/758.0.2 Darwin/15.0.0",
+    "iOSMajor": 9
+  },
+  {
+    "ua": "TestApp/1.0 CFNetwork/758.3.15 Darwin/15.4.0",
+    "iOSMajor": 9
+  },
+  {
+    "ua": "TestApp/1.0 CFNetwork/758.4.3 Darwin/15.5.0",
+    "iOSMajor": 9
+  },
+  {
+    "ua": "TestApp/1.0 CFNetwork/758.5.3 Darwin/15.6.0",
+    "iOSMajor": 9
+  },
+  {
+    "ua": "TestApp/1.0 CFNetwork/808.0.2 Darwin/16.0.0",
+    "iOSMajor": 10
+  },
+  {
+    "ua": "TestApp/1.0 CFNetwork/808.1.4 Darwin/16.1.0",
+    "iOSMajor": 10
+  },
+  {
+    "ua": "TestApp/1.0 CFNetwork/808.2.16 Darwin/16.3.0",
+    "iOSMajor": 10
+  },
+  {
+    "ua": "App/1.0.0 CFNetwork/808.3 Darwin/16.3.0",
+    "iOSMajor": 10
+  },
+  {
+    "ua": "Mozilla/5.0+(iPhone;+CPU+iPhone+OS+9_3_1+like+Mac+OS+X)+AppleWebKit/601.1.46+(KHTML,+like+Gecko)+Version/9.0+Mobile/13E238+Safari/601.1",
+    "iOSMajor": 9
+  },
+  {
+    "ua": "Mozilla/5.0+(iPad;+CPU+OS+9_3_1+like+Mac+OS+X)+AppleWebKit/601.1.46+(KHTML,+like+Gecko)+Version/9.0+Mobile/13E238+Safari/601.1",
+    "iOSMajor": 9
+  },
+  {
+    "ua": "Mozilla/5.0 (iPad; CPU iPad OS 14_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "Deezer/4.8.2 (iOS; 7.1; Mobile; de)",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "UCWEB/2.0 (iOS; U; iPd OS 7_0_4; zh-CN; iPd5,1) U2/1.0.0 UCBrowser/9.0.1.284 U2/1.0.0 Mobile",
+    "iOSMajor": 7
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU IPhone OS 8_1_3 Like Mac OS X) AppleWebKit/600.1.4 (KHTML, Like Gecko) CriOS/43.0.2357.61 Mobile/12B466 Safari/600.1.4",
+    "iOSMajor": 8
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU IPhone OS 9_2_1 Like Mac OS X) AppleWebKit/601.1.46 (KHTML, Like Gecko) Mobile/13D15 [FBAN/FBIOS;FBAV/52.0.0.46.157;FBBV/26424168;FBDV/iPhone6,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/9.2.1;FBSS/2; FBCR/Globe;FBID/phone;FBLC/en_US;FBOP/5]",
+    "iOSMajor": 9
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_4 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) Outlook-iOS-Android/1.0 Mobile/13G35 Safari/601.1.46\")",
+    "iOSMajor": 9
+  },
+  {
+    "ua": "MyApp/1.0 CFNetwork/811.4.18 Darwin/16.5.0",
+    "iOSMajor": 10
+  },
+  {
+    "ua": "MyApp/1.0 CFNetwork/811.5.4 Darwin/16.6.0",
+    "iOSMajor": 10
+  },
+  {
+    "ua": "MyApp/1.0 CFNetwork/811.5.4 Darwin/16.7.0",
+    "iOSMajor": 10
+  },
+  {
+    "ua": "MyApp/1.0 CFNetwork/887 Darwin/17.0.0",
+    "iOSMajor": 11
+  },
+  {
+    "ua": "MyApp/1.0 CFNetwork/889.9 Darwin/17.2.0",
+    "iOSMajor": 11
+  },
+  {
+    "ua": "MyApp/1.0 CFNetwork/893.10 Darwin/17.3.0",
+    "iOSMajor": 11
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 Instagram 33.0.0.11.96 (iPhone9,3; iOS 11_2_5; en_AU; en-AU; scale=2.00; gamut=wide; 750x1334)",
+    "iOSMajor": 11
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 Flipboard/4.2.2",
+    "iOSMajor": 11
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Phantom/ios/22.06.08.44",
+    "iOSMajor": 15
+  },
+  {
+    "ua": "ViaFree-DK/3.8.3 (com.MTGx.ViaFree.dk; build:7383; iOS 12.1.0) Alamofire/4.7.0",
+    "iOSMajor": 12
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.3 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15",
+    "iOSMajor": 14
+  },
+  {
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Pandora/1904.1.1",
+    "iOSMajor": 12
+  }
+]

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -155,6 +155,42 @@ for (const { input, expected } of [
   },
   {
     expected: {
+      gpu: 'apple a18 gpu',
+    },
+    input: {
+      isMobile: true,
+      renderer: 'Apple a18 GPU',
+    },
+  },
+  {
+    expected: {
+      gpu: 'apple a18 pro gpu',
+    },
+    input: {
+      isMobile: true,
+      renderer: 'Apple a18 pro GPU',
+    },
+  },
+  {
+    expected: {
+      gpu: 'apple m3',
+    },
+    input: {
+      isMobile: false,
+      renderer: 'Apple M3',
+    },
+  },
+  {
+    expected: {
+      gpu: 'apple m4',
+    },
+    input: {
+      isMobile: false,
+      renderer: 'Apple M4',
+    },
+  },
+  {
+    expected: {
       gpu: 'intel mesa dri intel uhd graphics 630',
     },
     input: {
@@ -274,6 +310,22 @@ for (const { input, expected } of [
   {
     isMobile: false,
     renderer: 'this renderer does not exist',
+  },
+  {
+    isMobile: true,
+    renderer: 'Apple a19 GPU',
+  },
+  {
+    isMobile: true,
+    renderer: 'Apple a19 pro GPU',
+  },
+  {
+    isMobile: true,
+    renderer: 'Apple a19pro GPU',
+  },
+  {
+    isMobile: false,
+    renderer: 'Apple M5',
   },
 ].map((settings) => {
   test(`${settings.renderer} should return FALLBACK`, async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -311,22 +311,6 @@ for (const { input, expected } of [
     isMobile: false,
     renderer: 'this renderer does not exist',
   },
-  {
-    isMobile: true,
-    renderer: 'Apple a19 GPU',
-  },
-  {
-    isMobile: true,
-    renderer: 'Apple a19 pro GPU',
-  },
-  {
-    isMobile: true,
-    renderer: 'Apple a19pro GPU',
-  },
-  {
-    isMobile: false,
-    renderer: 'Apple M5',
-  },
 ].map((settings) => {
   test(`${settings.renderer} should return FALLBACK`, async () => {
     expectGPUResults(

--- a/test/iosUserAgents.test.ts
+++ b/test/iosUserAgents.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest';
+
+import { parseIOSVersion } from '../src/internal/deviceInfo';
+import fixtures from './fixtures/ios-user-agents.json';
+
+// The contract we test: for any UA in the corpus, our parser must either
+// return the same major version OR return undefined when the UA carries no
+// token we attempt to parse (in-app browsers, etc.). Returning a *wrong*
+// major is the failure mode we care about.
+
+const ALL = fixtures;
+const OS_TOKEN = /(?:iPhone|CPU) OS \d+_/;
+const VERSION_TOKEN = /Version\/\d+/;
+
+describe('parseIOSVersion (uap-core corpus)', () => {
+  test('never returns a wrong major version', () => {
+    const wrong = ALL.filter((entry) => {
+      const result = parseIOSVersion(entry.ua, true);
+      return result !== undefined && result !== entry.iOSMajor;
+    });
+    expect(wrong).toEqual([]);
+  });
+
+  test('extracts a value for the majority of standard browser UAs', () => {
+    // "Standard" = UA contains either the "iPhone OS"/"CPU OS" token or
+    // "Version/" — i.e. the patterns we explicitly handle. We expect 100%
+    // recognition on these; in-app browsers without those tokens are out
+    // of scope and verified separately.
+    const standard = ALL.filter(
+      (entry) => OS_TOKEN.test(entry.ua) || VERSION_TOKEN.test(entry.ua)
+    );
+    const recognized = standard.filter(
+      (entry) => parseIOSVersion(entry.ua, true) === entry.iOSMajor
+    );
+    expect(recognized.length).toBe(standard.length);
+  });
+
+  test('returns undefined for non-iOS context regardless of UA content', () => {
+    for (const entry of ALL) {
+      expect(parseIOSVersion(entry.ua, false)).toBeUndefined();
+    }
+  });
+});
+
+describe('parseIOSVersion (pre-iOS-7 Safari/iOS mismatch)', () => {
+  // iOS 3.2 shipped Safari 4.0.4; iOS 4 shipped Safari 5.0.2. Apple only
+  // aligned the Safari marketed version with the iOS major at iOS 7. So
+  // "Version/" can't be trusted on pre-iOS-7 UAs — the OS token wins.
+  test('trusts "OS 3_2" over "Version/4"', () => {
+    const ua =
+      'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10';
+    expect(parseIOSVersion(ua, true)).toBe(3);
+  });
+  test('trusts "iPhone OS 4_3_2" over "Version/5"', () => {
+    const ua =
+      'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5';
+    expect(parseIOSVersion(ua, true)).toBe(4);
+  });
+});
+
+describe('parseIOSVersion (OS token separator variants)', () => {
+  // Canonical form is "iPhone OS 17_2" with underscores between digits, but
+  // older and in-app UAs use "." or follow the major with ";" / " " / ")".
+  // All of these are real corpus shapes.
+  test('accepts "iPhone OS 7.0;" (dot separator, in-app browser)', () => {
+    const ua = 'iTube 2.15 (iPhone; iPhone OS 7.0; en_US)';
+    expect(parseIOSVersion(ua, true)).toBe(7);
+  });
+  test('accepts the canonical "iPhone OS 17_2" underscore form', () => {
+    const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X)';
+    expect(parseIOSVersion(ua, true)).toBe(17);
+  });
+});
+
+describe('parseIOSVersion (iOS 26 UA freeze)', () => {
+  // In iOS 26 Apple froze the legacy "iPhone OS 18_6" token to reduce
+  // fingerprinting; the true OS major is exposed only via "Version/N".
+  // SEE: https://webkit.org/blog/ (UA reduction work) and ua-parser-js
+  // commit history for the iOS 26 fixture that first surfaced this.
+  test('ignores the frozen "iPhone OS 18_6" token and reads Version/26', () => {
+    const ua =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1';
+    expect(parseIOSVersion(ua, true)).toBe(26);
+  });
+});


### PR DESCRIPTION
## Summary

Builds on @HarshdeepKahlon's #146 with UA-aware iOS version detection, chipset-candidate filtering, a few corrections on the chip additions, a small perf win, and one dep drop.

## Commits

1. `97b23ff` / `700b0f1` — @HarshdeepKahlon's chipset additions (A18 / A18 Pro / A19 / A19 Pro on iPhone; M3 / M4 / M5 on iPad), picked from #146.
2. `9b21de2` — our combined feature commit.

## What's in the combined commit

### 1. Chipset corrections

- Rename the iPhone A17 entry to `a17 pro`. Apple only ever shipped A17 Pro, and `apple a17 gpu` did not exist in any benchmark file, so the previous entry emitted a string that never matched.
- Add A16 (2025 iPad Air / iPad 11) and A17 Pro (iPad mini 7) to the **iPad** chipset list.
- Drop FALLBACK test cases for A19 / A19 Pro / M5 — all three are present in the benchmark JSON and correctly resolve to BENCHMARK.

### 2. UA-aware chipset filter

On iOS Safari the WebGL renderer is masked to `Apple GPU`. detect-gpu works around this with a fragment-shader pixel-ID trick that yields a pool of candidate chips; the benchmark matcher picks one by screen-size distance. The candidate pool previously included every chip that could theoretically run iOS 14+ — far wider than necessary.

This PR parses the iOS major version from the UA and drops chips the device cannot run:

| OS | Min iPhone chip | Min iPad chip |
|---|---|---|
| iOS/iPadOS 13–15 | A9 | A8 |
| iOS/iPadOS 16 | A10 | A9 |
| iOS/iPadOS 17–18 | A12 | A10 |
| iOS/iPadOS 26 | A13 | A12 |

### 3. UA parsing edge cases

- **iOS 26+ freezes the `iPhone OS 18_6` token** as a fingerprinting countermeasure. The real iOS major is exposed only via `Version/N`. The parser prefers `Version/` whenever it disagrees upward with the OS token.
- **Pre-iOS-7 Safari `Version/` tracked Safari, not iOS** (Safari 4 on iOS 3.2, Safari 5 on iOS 4). Falls back to the OS token when `OS < 7`.
- **iPadOS "Request Desktop Site"** UAs are `Mozilla/5.0 (Macintosh; ...)` with no iPhone/iPad token. The parser still fires because `isIpad` is true via `MacIntel + maxTouchPoints > 0`.
- **In-app browsers** (Facebook, Slack, Snapchat, etc.) hide the iOS version in proprietary tokens. These yield `undefined` → the filter becomes a safe no-op.

### 4. Pixel-ID shader short-circuit on iOS 14+

Apple normalized the shader output in iOS 14, so all modern devices return the same `codeFB` — which the old code used purely as a "this is iOS 14+" signal. The UA now provides that signal directly, without the shader compile + draw + `readPixels` round-trip. The shader path is retained as the fallback for iOS 12.x / 13.x devices, where the three distinct pixel IDs still discriminate A7 vs A8–A10 vs A11+ within a single iOS version.

### 5. Drop `webgl-constants` dependency

The shader function used 9 WebGL enum constants (`GL_ARRAY_BUFFER`, `GL_FLOAT`, etc.) from the `webgl-constants` package. Inlined them as module-local `const` declarations with a Khronos spec link; minifier gets the same literal folding, one fewer runtime dependency.

## Tests

- `test/deobfuscateAppleGPU.test.ts` — 11 unit tests for `filterByIOSVersion`, covering every cutoff and the M-series passthrough.
- `test/deviceInfo.test.ts` — 6 UA-shape tests for `parseIOSVersion` via a stubbed `navigator`.
- `test/iosUserAgents.test.ts` — runs `parseIOSVersion` against a 129-entry iOS UA corpus (iOS 1–18) sourced from `ua-parser/uap-core`'s `test_os.yaml`, plus explicit pre-iOS-7 / iOS 26 freeze / separator-variant tests. Asserts the parser never returns a *wrong* major and recognizes 100% of UAs with one of the two standard tokens.
- `test/fixtures/ios-user-agents.json` — the 129-entry corpus.

All 1666 tests pass; lint, format, build, and typecheck clean. Bundle: 7.65 kB / 3.61 kB gzip.

## Suggested release bump

Adds new behavior (filtering) and a new exported helper (`parseIOSVersion`). Suggest a **minor** bump when triggering the release workflow.

## Test plan

- [x] `pnpm test` — 1666 tests pass
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [x] `pnpm build` succeeds
- [ ] CI confirms the same