### PR TITLE
chore: drop dead IE11 MSStream check in iPadOS detection

### DIFF
--- a/src/internal/deviceInfo.ts
+++ b/src/internal/deviceInfo.ts
@@ -34,13 +34,16 @@ export const deviceInfo = (() => {
 
   const isIOS = /(iphone|ipod|ipad)/i.test(userAgent);
 
-  // Workaround for ipadOS, force detection as tablet
+  // Workaround for ipadOS, force detection as tablet. `platform` is
+  // deprecated but remains the only reliable way to distinguish iPadOS
+  // desktop-mode (MacIntel + touch) from a real Mac on Safari/Firefox.
+  // Known limitation: if Apple ever ships a touch-screen Mac, it will
+  // also match `MacIntel + maxTouchPoints > 0` and be misclassified as
+  // iPad here. No such device exists today; revisit when/if it ships.
   // SEE: https://github.com/lancedikson/bowser/issues/329
   // SEE: https://stackoverflow.com/questions/58019463/how-to-detect-device-name-in-safari-on-ios-13-while-it-doesnt-show-the-correct
   const isIpad =
-    platform === 'iPad' ||
-    // @ts-expect-error window.MSStream is non standard
-    (platform === 'MacIntel' && maxTouchPoints > 0 && !window.MSStream);
+    platform === 'iPad' || (platform === 'MacIntel' && maxTouchPoints > 0);
 
   const isAndroid = /android/i.test(userAgent);
 


### PR DESCRIPTION
## Summary

The `!window.MSStream` clause in the iPadOS detection branch was imported from a circa-2013 Stack Overflow snippet that used it to exclude Internet Explorer on Windows Phone from being detected as iOS. It was never reachable under the \`platform === 'MacIntel'\` branch — IE never ran on macOS — so the guard was dead the day it was added. IE itself has been EOL since June 2022.

Removing it also drops the \`@ts-expect-error\` comment it justified (since \`window.MSStream\` isn't in the DOM lib types).

## Bonus: comment upgrades

- One-line note on why \`navigator.platform\` (deprecated per MDN) is still in use here: \`navigator.userAgentData.platform\` is Chromium-only and doesn't expose the iPadOS-as-MacIntel masquerade.
- Acknowledge a known forward-looking limitation: if Apple ever ships a touchscreen Mac, it will also match \`MacIntel + maxTouchPoints > 0\` and be misclassified as iPad here. No such device exists today; revisit when/if it ships. (\`navigator.standalone\` was considered as a Touch-Mac-proof alternative, but I verified on macOS Safari today that \`typeof navigator.standalone === 'boolean'\` — Apple extended it to macOS at some point, so it can't be used to discriminate Mac from iPad anymore.)

## Diff

```ts
-  // Workaround for ipadOS, force detection as tablet
+  // Workaround for ipadOS, force detection as tablet. `platform` is
+  // deprecated but remains the only reliable way to distinguish iPadOS
+  // desktop-mode (MacIntel + touch) from a real Mac on Safari/Firefox.
+  // Known limitation: if Apple ever ships a touch-screen Mac, it will
+  // also match `MacIntel + maxTouchPoints > 0` and be misclassified as
+  // iPad here. No such device exists today; revisit when/if it ships.
   // SEE: https://github.com/lancedikson/bowser/issues/329
   // SEE: https://stackoverflow.com/questions/58019463/how-to-detect-device-name-in-safari-on-ios-13-while-it-doesnt-show-the-correct
   const isIpad =
-    platform === 'iPad' ||
-    // @ts-expect-error window.MSStream is non standard
-    (platform === 'MacIntel' && maxTouchPoints > 0 && !window.MSStream);
+    platform === 'iPad' || (platform === 'MacIntel' && maxTouchPoints > 0);
```

## Test plan

- [x] \`pnpm test\` — all tests pass
- [x] \`pnpm lint\` passes
- [x] \`pnpm format:check\` passes
- [x] \`pnpm build\` succeeds