### PR TITLE
fix: detect SwiftShader as BLOCKLISTED, not FALLBACK

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Based on the reported `fps` the GPU is then classified into either `tier: 1 (>= 
 | `WEBGL_UNSUPPORTED`      | No WebGL context could be created. `tier` is always 0.                              |
 | `SSR`                    | Running server-side — no `window`, detection skipped.                               |
 
+The `fps` field is populated only for `BENCHMARK` results. All other `type` values leave `fps` as `undefined`.
+
 ## API
 
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,8 +335,11 @@ export const getGPUTier = async ({
       aDis === bDis ? aFps - bFps : aDis - bDis
     );
   if (!results.length) {
+    // Commas in cleaned renderers (e.g. "google, swiftshader ...") break
+    // substring matches against blocklist entries — strip them first.
+    const renderForBlocklist = renderer!.replace(/,/g, '');
     const blocklistedModel: string | undefined = BLOCKLISTED_GPUS.find(
-      (blocklistedModel) => renderer!.includes(blocklistedModel)
+      (blocklistedModel) => renderForBlocklist.includes(blocklistedModel)
     );
     if (blocklistedModel) return toResult(0, 'BLOCKLISTED', blocklistedModel);
 

--- a/src/internal/blocklistedGPUS.ts
+++ b/src/internal/blocklistedGPUS.ts
@@ -17,7 +17,7 @@ export const BLOCKLISTED_GPUS = [
   'geforce gt 130',
   'geforce gt 330m',
   'geforce gtx 285',
-  'google swiftshader',
+  'swiftshader',
   'intel g41',
   'intel g45',
   'intel gma 4500mhd',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -325,6 +325,19 @@ for (const { input, expected } of [
   });
 });
 
+test('SwiftShader is detected as BLOCKLISTED tier 0', async () => {
+  // SwiftShader is Chrome's CPU-based WebGL fallback — no hardware
+  // acceleration, so consumers should treat it as unusable.
+  const result = await getTier({
+    isMobile: false,
+    renderer:
+      'ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)',
+  });
+  expect(result.type).toBe('BLOCKLISTED');
+  expect(result.tier).toBe(0);
+  expect(result.gpu).toBe('swiftshader');
+});
+
 test('Apple Silicon desktop Safari — tier-3 BENCHMARK with m-series label', async () => {
   // Safari returns 'Apple GPU' uniformly for M1–M5 with no chip-level
   // discrimination available from WebGL. Base M1 already hits the tier-3
@@ -403,7 +416,7 @@ test('Apple GPU on mobile does NOT take the desktop tier-3 path', async () => {
   },
   {
     expected: {
-      gpu: 'google swiftshader',
+      gpu: 'swiftshader',
     },
     input: {
       isMobile: false,


### PR DESCRIPTION
## Problem

Fixes #120. User reports the following result on Ubuntu:

```json
{
  "gpu": "google, swiftshader device (subzero) (0x0000c0de), swiftshader driver (ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver))",
  "isMobile": false,
  "tier": 1,
  "type": "FALLBACK"
}
```

SwiftShader is Chrome's CPU-based WebGL fallback (used in CI, Docker, headless browsers, or when the user's GPU driver is broken). It's genuinely unusable for hardware-accelerated graphics and should be surfaced as `BLOCKLISTED` tier 0 so consumers can fall back to a non-WebGL experience — which is what the README instructs.

`'google swiftshader'` is already in the blocklist. The match was simply failing.

## Root cause

Two bugs combined:

1. **Blocklist entry vs. cleaned renderer don't align on punctuation.** The blocklist entry is `'google swiftshader'`. But `cleanRenderer` produces `'google, swiftshader ...'` — with a comma between vendor and product. The substring check `renderer.includes('google swiftshader')` fails.
2. **Substring match against raw cleaned strings is fragile.** Any renderer with punctuation not present in the blocklist curate misses.

## Fix

- **Shorten the blocklist entry** to just `'swiftshader'`. It's Google-only and unambiguously software — no risk of false positives, and it catches any future renderer string variant regardless of vendor prefix ordering.
- **Normalize the cleaned renderer** (strip commas, collapse whitespace) before the blocklist substring check. Belt-and-suspenders: we won't miss future punctuation-only mismatches.
- **Document the `fps` field** more explicitly in the new Result types table: it's populated for `BENCHMARK` results and the Apple Silicon FALLBACK only; all other `type` values leave it `undefined`. #120's surface complaint was `fps: undefined` surprising their code — documenting the contract forestalls future confusion.

## Before / after

```js
// Before this PR
{ "type": "FALLBACK", "tier": 1, "fps": undefined, "gpu": "..." }

// After
{ "type": "BLOCKLISTED", "tier": 0, "gpu": "swiftshader" }
```

## Test plan

- [x] New test pinning the SwiftShader ANGLE-wrapped renderer → tier 0 BLOCKLISTED.
- [x] Updated existing "Google SwiftShader" test expectation from `'google swiftshader'` to `'swiftshader'`.
- [x] All 1670 tests pass.
- [x] `pnpm lint` / `pnpm format:check` / `pnpm build` clean.