### PR TITLE
fix: point types to emitted declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs"
     }
   },
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "homepage": "https://github.com/pmndrs/detect-gpu#readme",
   "bugs": {
     "url": "https://github.com/pmndrs/detect-gpu/issues"


### PR DESCRIPTION
## Summary
- update the package-level `types` field to `./dist/index.d.mts`
- update the root export `types` condition to the same emitted declaration file

## Why
The published `@pmndrs/detect-gpu@6.0.9` tarball includes `dist/index.d.mts`, but not `dist/index.d.ts`. TypeScript and package metadata consumers that read `types` or the export `types` condition currently resolve a missing declaration file.

## Validation
- `npm pack @pmndrs/detect-gpu@6.0.9 --silent` confirmed `package/dist/index.d.mts` exists and `package/dist/index.d.ts` is absent
- `node -e "const p=require('./package.json'); if(p.types!=='./dist/index.d.mts') process.exit(1); if(p.exports['.'].types!==p.types) process.exit(2)"`
- `git diff --check`