### PR TITLE
fix: remove engines.node from published package (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ getGPUTier({
 
 ## Requirements
 
-- Node.js 24+
 - ESM only (CommonJS is not supported)
 
 ## Support

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "@pmndrs/detect-gpu",
   "version": "6.0.9",
   "packageManager": "pnpm@10.13.1",
-  "engines": {
-    "node": ">=24"
-  },
   "description": "Classify GPU's based on their benchmark score in order to provide an adaptive experience.",
   "author": "Tim van Scherpenzeel",
   "license": "MIT",


### PR DESCRIPTION
## Problem

Since `v6.0.1`, `@pmndrs/detect-gpu` declares `engines.node: ">=24"`. Under `engine-strict=true` this hard-fails consumer installs on Node 20/22 LTS:

```
npm error code EBADENGINE
npm error Required: {"node":">=24"}
npm error Actual:   {"node":"v22.17.0","npm":"11.4.2"}
```

The library is browser-only — the published `dist` only uses `window`, `navigator`, WebGL and `fetch`, with no Node runtime requirement. The `>=24` constraint leaked in from a dev-environment bump (`chore: bump node version to 24`).

## Fix

Remove the `engines` field entirely, restoring the `v6.0.0` behavior (which had no `engines`).

The build/publish Node version is enforced independently of this field and is unaffected:
- `.nvmrc` → `24` (local dev)
- `node-version: '24'` hard-pinned in both `.github/workflows/test.yml` and `release.yml`

Also removes the now-inaccurate "Node.js 24+" consumer requirement from the README.

Fixes #165